### PR TITLE
fix: Remove docker-compose version key to fix warnings

### DIFF
--- a/README_AGENTIC.md
+++ b/README_AGENTIC.md
@@ -187,7 +187,6 @@ The agentic workflow uses two Docker Compose files:
 The system automatically generates a `docker-compose-agent.yml` file with:
 
 ```yaml
-version: '3'
 services:
   agent:
     image: your-agent-name
@@ -205,7 +204,6 @@ services:
 The test harness uses a `docker-compose.yml` file from the dataset, or generates a default:
 
 ```yaml
-version: '3'
 services:
   test:
     image: us-central1-docker.pkg.dev/turing-gpt/verilogeval/cadence-tools
@@ -459,7 +457,6 @@ echo '{"prompt": "test task"}' > test_agent/prompt.json
 
 # Create docker-compose.yml
 cat > test_agent/docker-compose.yml << EOF
-version: '3'
 services:
   agent:
     image: my-agent

--- a/src/dataset_processor.py
+++ b/src/dataset_processor.py
@@ -1587,7 +1587,6 @@ class AgenticProcessor (DatasetProcessor):
         if use_git_workspace and workspace_volume:
             # Use volume-based mounting for git workspaces
             docker_compose = {
-                'version': '3',
                 'services': {
                     'agent': {
                         'image': agent,
@@ -1612,7 +1611,6 @@ class AgenticProcessor (DatasetProcessor):
         else:
             # Use traditional directory-based mounting
             docker_compose = {
-                'version': '3',
                 'services': {
                     'agent': {
                         'image': agent,

--- a/src/network_util.py
+++ b/src/network_util.py
@@ -139,7 +139,7 @@ def add_network_to_docker_compose(docker_compose_path, network_name):
         
         # If the file is empty or invalid, create a basic structure
         if not data:
-            data = {'version': '3', 'services': {}}
+            data = {'services': {}}
         
         # Check if networks section already exists and if it has a default network
         if 'networks' not in data or 'default' not in data.get('networks', {}):


### PR DESCRIPTION
Fixes #23 

### Example Before

```
Running agent with project name: agent_cvdp_agentic_fixed_arbiter_1_1761605267
time="2025-10-27T16:47:48-06:00" level=warning msg=".../cvdp_agentic_fixed_arbiter/harness/1/docker-compose-agent.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion"
Starting CVDP agent...
```

### Example After

```
Running agent with project name: agent_cvdp_agentic_fixed_arbiter_1_1761606093
Starting CVDP agent...
Analyzing prompt: Design a `fixed_priority_arbiter` module in SystemVerilog within a file fixed_priority_arbiter.sv at the location:rtl/fixed_priority_arbiter.v. Refer to the specification provided in docs/specification.md and ensure you understand its content. The specification details the arbitration mechanism, request handling logic, priority override functionality, an example of arbitration behavior, the required module interface, internal architecture, and timing requirements. Generate the complete RTL code that implements the `fixed_priority_arbiter`, which follows a fixed-priority arbitration scheme while allowing an external priority override mechanism.
```