### PR TITLE
Fixed missing src volume mount in traditional directory-based mounting

### DIFF
--- a/src/dataset_processor.py
+++ b/src/dataset_processor.py
@@ -1638,6 +1638,7 @@ class AgenticProcessor (DatasetProcessor):
                             './docs:/code/docs',
                             './rtl:/code/rtl',
                             './verif:/code/verif',
+                            './src:/code/src',
                             './rundir:/code/rundir',
                             './prompt.json:/code/prompt.json'
                         ],


### PR DESCRIPTION
The ./src:/code/src volume mount was missing from the traditional 
directory-based mounting configuration, which would have prevented 
testbench files from being accessible to the agent container.