### PR TITLE
[FIX] - Add memory quotas to Docker runs

### DIFF
--- a/README_DEVELOPER.md
+++ b/README_DEVELOPER.md
@@ -196,8 +196,12 @@ The `dir_monitor.py` module provides automatic monitoring of Docker workspace di
 - `DOCKER_QUOTA_THRESHOLD_MB` - Size limit before termination (default: 50)
 - `DOCKER_QUOTA_CHECK_INTERVAL` - Check frequency in seconds (default: 1)
 - `DOCKER_QUOTA_MIN_COMPRESS_SIZE_MB` - Minimum file size for compression (default: 10)
+- `DOCKER_HARNESS_MEMORY_LIMIT` - Memory limit for harness Docker containers (e.g., '12g'). Sets both --memory and --memory-swap. If not set, no memory limits are applied (default: None)
+- `DOCKER_AGENT_MEMORY_LIMIT` - Memory limit for agent Docker containers (e.g., '12g'). Sets both --memory and --memory-swap. If not set, no memory limits are applied (default: None)
 
 **Note:** File compression is currently disabled by default in the codebase but can be enabled via the `compress_on_threshold` parameter.
+
+**Memory Quotas:** Memory limits can be set separately for harness and agent containers to prevent runaway memory usage from incorrectly generated Verilog code. When set, Docker will kill containers that exceed the specified memory limit. This helps prevent host system instability.
 
 ### Commercial EDA Tool Management
 

--- a/README_FULL.md
+++ b/README_FULL.md
@@ -451,6 +451,8 @@ The benchmark includes automatic monitoring of Docker workspace directories to p
 - `DOCKER_QUOTA_THRESHOLD_MB` - Size limit before termination
 - `DOCKER_QUOTA_CHECK_INTERVAL` - Check frequency in seconds  
 - `DOCKER_QUOTA_MIN_COMPRESS_SIZE_MB` - Minimum file size for compression
+- `DOCKER_HARNESS_MEMORY_LIMIT` - Memory limit for harness Docker containers (e.g., '12g'). Sets both --memory and --memory-swap
+- `DOCKER_AGENT_MEMORY_LIMIT` - Memory limit for agent Docker containers (e.g., '12g'). Sets both --memory and --memory-swap
 
 For detailed configuration and implementation details, see [README_DEVELOPER.md](README_DEVELOPER.md).
 

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -124,6 +124,10 @@ class ConfigManager:
                            description="Docker quota check interval in seconds")
         self.register_config("DOCKER_QUOTA_MIN_COMPRESS_SIZE_MB", default=10, type_cast=int,
                            description="Minimum file size in MB before compression")
+        self.register_config("DOCKER_HARNESS_MEMORY_LIMIT", default=None, type_cast=str,
+                           description="Memory limit for harness Docker containers (e.g., '12g'). Sets both --memory and --memory-swap")
+        self.register_config("DOCKER_AGENT_MEMORY_LIMIT", default=None, type_cast=str,
+                           description="Memory limit for agent Docker containers (e.g., '12g'). Sets both --memory and --memory-swap")
         
         # EDA Tool Infrastructure Configuration
         self.register_config("VERIF_EDA_IMAGE", default="cvdp-cadence-verif:latest", type_cast=str,

--- a/src/dataset_processor.py
+++ b/src/dataset_processor.py
@@ -1963,12 +1963,21 @@ class AgenticProcessor (DatasetProcessor):
             script_file.write(f"echo \"Running agent with project name: {project_name}\"\n")
             script_file.write(f"# Get current user and group IDs\n")
             script_file.write(f"USER_ID=$(id -u)\n")
-            script_file.write(f"GROUP_ID=$(id -g)\n\n")
+            script_file.write(f"GROUP_ID=$(id -g)\n")
+            
+            # Add memory limits if configured
+            agent_memory_limit = config.get("DOCKER_AGENT_MEMORY_LIMIT")
+            memory_flags = ""
+            if agent_memory_limit:
+                memory_flags = f" --memory={agent_memory_limit} --memory-swap={agent_memory_limit}"
+                script_file.write(f"# Memory limit: {agent_memory_limit}\n")
+            script_file.write(f"\n")
+            
             script_file.write(f"if [ \"$DEBUG_MODE\" = true ]; then\n")
             script_file.write(f"  echo \"DEBUG MODE: Starting container with bash entrypoint\"\n")
-            script_file.write(f"  docker compose -f {docker_compose_path} -p {project_name} run --rm --user $USER_ID:$GROUP_ID --entrypoint bash agent\n")
+            script_file.write(f"  docker compose -f {docker_compose_path} -p {project_name} run --rm{memory_flags} --user $USER_ID:$GROUP_ID --entrypoint bash agent\n")
             script_file.write(f"else\n")
-            script_file.write(f"  docker compose -f {docker_compose_path} -p {project_name} run --rm --user $USER_ID:$GROUP_ID agent\n")
+            script_file.write(f"  docker compose -f {docker_compose_path} -p {project_name} run --rm{memory_flags} --user $USER_ID:$GROUP_ID agent\n")
             script_file.write(f"fi\n")
             script_file.write(f"exit_code=$?\n\n")
             script_file.write(f"# Exit with the same code as the docker command\n")

--- a/src/repository.py
+++ b/src/repository.py
@@ -457,12 +457,21 @@ class Repository:
             script_file.write(f"echo \"Running harness with project name: {project_name}\"\n")
             script_file.write(f"# Get current user and group IDs\n")
             script_file.write(f"USER_ID=$(id -u)\n")
-            script_file.write(f"GROUP_ID=$(id -g)\n\n")
+            script_file.write(f"GROUP_ID=$(id -g)\n")
+            
+            # Add memory limits if configured
+            harness_memory_limit = config.get("DOCKER_HARNESS_MEMORY_LIMIT")
+            memory_flags = ""
+            if harness_memory_limit:
+                memory_flags = f" --memory={harness_memory_limit} --memory-swap={harness_memory_limit}"
+                script_file.write(f"# Memory limit: {harness_memory_limit}\n")
+            script_file.write(f"\n")
+            
             script_file.write(f"if [ \"$DEBUG_MODE\" = true ]; then\n")
             script_file.write(f"  echo \"DEBUG MODE: Starting container with bash entrypoint\"\n")
-            script_file.write(f"  docker compose -f {docker} -p {project_name} run --rm --user $USER_ID:$GROUP_ID -e HOME=/code/rundir --entrypoint bash {cmd} {service}\n")
+            script_file.write(f"  docker compose -f {docker} -p {project_name} run --rm{memory_flags} --user $USER_ID:$GROUP_ID -e HOME=/code/rundir --entrypoint bash {cmd} {service}\n")
             script_file.write(f"else\n")
-            script_file.write(f"  docker compose -f {docker} -p {project_name} run --rm --user $USER_ID:$GROUP_ID -e HOME=/code/rundir {cmd} {service}\n")
+            script_file.write(f"  docker compose -f {docker} -p {project_name} run --rm{memory_flags} --user $USER_ID:$GROUP_ID -e HOME=/code/rundir {cmd} {service}\n")
             script_file.write(f"fi\n")
             script_file.write(f"exit_code=$?\n\n")
             script_file.write(f"# Exit with the same code as the docker command\n")
@@ -786,12 +795,21 @@ class Repository:
             script_file.write(f"echo \"Running agent with project name: {project_name}\"\n")
             script_file.write(f"# Get current user and group IDs\n")
             script_file.write(f"USER_ID=$(id -u)\n")
-            script_file.write(f"GROUP_ID=$(id -g)\n\n")
+            script_file.write(f"GROUP_ID=$(id -g)\n")
+            
+            # Add memory limits if configured
+            agent_memory_limit = config.get("DOCKER_AGENT_MEMORY_LIMIT")
+            memory_flags = ""
+            if agent_memory_limit:
+                memory_flags = f" --memory={agent_memory_limit} --memory-swap={agent_memory_limit}"
+                script_file.write(f"# Memory limit: {agent_memory_limit}\n")
+            script_file.write(f"\n")
+            
             script_file.write(f"if [ \"$DEBUG_MODE\" = true ]; then\n")
             script_file.write(f"  echo \"DEBUG MODE: Starting container with bash entrypoint\"\n")
-            script_file.write(f"  docker compose -f {docker_compose_path} -p {project_name} run --rm --user $USER_ID:$GROUP_ID --entrypoint bash agent\n")
+            script_file.write(f"  docker compose -f {docker_compose_path} -p {project_name} run --rm{memory_flags} --user $USER_ID:$GROUP_ID --entrypoint bash agent\n")
             script_file.write(f"else\n")
-            script_file.write(f"  docker compose -f {docker_compose_path} -p {project_name} run --rm --user $USER_ID:$GROUP_ID agent\n")
+            script_file.write(f"  docker compose -f {docker_compose_path} -p {project_name} run --rm{memory_flags} --user $USER_ID:$GROUP_ID agent\n")
             script_file.write(f"fi\n")
             script_file.write(f"exit_code=$?\n\n")
             script_file.write(f"# Exit with the same code as the docker command\n")


### PR DESCRIPTION
Implement configurable memory limits for Docker containers to prevent runaway memory usage from incorrectly generated Verilog code.

Changes:
- Add DOCKER_HARNESS_MEMORY_LIMIT and DOCKER_AGENT_MEMORY_LIMIT config options
- Apply memory limits via --memory and --memory-swap flags in shell scripts
- Memory limits applied to harness/evaluation containers (where iverilog runs)
- Memory limits applied to agent containers (both code paths)
- Backwards compatible: defaults to None (no limits if not configured)
- Updated documentation in README_DEVELOPER.md and README_FULL.md

Closes #18 