### PR TITLE
Add claude code agent benchmarking

### DIFF
--- a/examples/claude-code-agent/Dockerfile
+++ b/examples/claude-code-agent/Dockerfile
@@ -1,0 +1,53 @@
+FROM ubuntu:22.04
+
+# Prevent interactive prompts during package installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install dependencies
+RUN apt-get update && apt-get install -y \
+    curl \
+    python3 \
+    python3-pip \
+    git \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Node.js 20.x (required for Claude Code which needs >= 18)
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+    apt-get install -y nodejs && \
+    rm -rf /var/lib/apt/lists/*
+
+# Verify Node.js version
+RUN node --version && npm --version
+
+# Install Claude Code CLI via npm
+RUN npm install -g @anthropic-ai/claude-code
+
+# Verify Claude installation
+RUN which claude && claude --version
+
+# Create a non-root user for Claude (required for --dangerously-skip-permissions)
+RUN useradd -m -u 1001 -s /bin/bash claude && \
+    mkdir -p /home/claude/.config/claude && \
+    chown -R claude:claude /home/claude && \
+    chmod 755 /home/claude && \
+    chmod -R u+w /home/claude
+
+ENV HOME=/home/claude
+
+# Copy agent wrapper
+WORKDIR /app
+COPY agent.py .
+RUN chmod +x agent.py && chown claude:claude agent.py
+
+# Create /code directory and set permissions
+RUN mkdir -p /code && chown -R claude:claude /code
+
+# Set environment variable to indicate we're in a container
+ENV CLAUDE_CODE_CONTAINER=1
+
+# Switch to non-root user
+USER claude
+
+# Set the entrypoint
+ENTRYPOINT ["python3", "/app/agent.py"]

--- a/examples/claude-code-agent/Dockerfile.commercial
+++ b/examples/claude-code-agent/Dockerfile.commercial
@@ -1,0 +1,97 @@
+FROM rockylinux/rockylinux:9
+
+WORKDIR /
+
+# Install system dependencies (same as cadence_docker base)
+RUN dnf update -y && dnf upgrade -y
+RUN dnf install -y --allowerasing \
+    ksh \
+    tcsh \
+    perl \
+    libnsl \
+    libxcrypt-compat \
+    which \
+    git \
+    make \
+    file \
+    coreutils \
+    iputils \
+    bind-utils \
+    curl \
+    ca-certificates
+
+# Required for lmstat
+RUN ln -s /lib64/ld-linux-x86-64.so.2 /lib64/ld-lsb-x86-64.so.3
+
+# Cadence tools will be mounted at runtime from /opt/cadence/installs
+# Set PATH to access the tools (use 64-bit binaries)
+ENV PATH="$PATH:/opt/cadence/installs/XCELIUM2403/tools.lnx86/inca/bin/64bit"
+ENV PATH="$PATH:/opt/cadence/installs/XCELIUMML2403/tools.lnx86/bin"
+ENV PATH="$PATH:/opt/cadence/installs/VMANAGER2403/bin"
+
+# Set MDV_XLM_HOME for Xcelium coverage analysis
+ENV MDV_XLM_HOME="/opt/cadence/installs/XCELIUM2403"
+
+# License server configuration - set as build args
+ARG CDS_LIC_FILE
+ARG LM_LICENSE_FILE
+RUN test -n "$CDS_LIC_FILE" || (echo "ERROR: CDS_LIC_FILE build arg required" && exit 1)
+RUN test -n "$LM_LICENSE_FILE" || (echo "ERROR: LM_LICENSE_FILE build arg required" && exit 1)
+ENV CDS_LIC_FILE=$CDS_LIC_FILE
+ENV LM_LICENSE_FILE=$LM_LICENSE_FILE
+
+# ----------------------------------------
+# - Preparing Python Environment
+# ----------------------------------------
+
+RUN dnf -y install python3.12
+ADD https://bootstrap.pypa.io/get-pip.py get-pip.py
+RUN python3 ./get-pip.py
+# Install cocotb 1.9.x which includes runner module, or install separately
+RUN python3 -m pip install pytest pytest-timeout "cocotb<2.0" || \
+    python3 -m pip install pytest pytest-timeout cocotb cocotb-runner
+
+# ----------------------------------------
+# - Install Claude Code CLI
+# ----------------------------------------
+
+# Install Node.js 20.x (required for Claude Code which needs >= 18)
+RUN curl -fsSL https://rpm.nodesource.com/setup_20.x | bash - && \
+    dnf install -y nodejs && \
+    dnf clean all
+
+# Verify Node.js version
+RUN node --version && npm --version
+
+# Install Claude Code CLI via npm
+RUN npm install -g @anthropic-ai/claude-code
+
+# Verify Claude installation
+RUN which claude && claude --version
+
+# Create a non-root user for Claude (required for --dangerously-skip-permissions)
+RUN useradd -m -u 1001 -s /bin/bash claude && \
+    mkdir -p /home/claude/.config/claude && \
+    chown -R claude:claude /home/claude && \
+    chmod 755 /home/claude && \
+    chmod -R u+w /home/claude
+
+ENV HOME=/home/claude
+
+# Copy agent wrapper
+WORKDIR /app
+COPY agent.py .
+RUN chmod +x agent.py && chown claude:claude agent.py
+
+# Create /code directory and set permissions
+RUN mkdir -p /code && chown -R claude:claude /code
+
+# Set environment variable to indicate we're in a container with EDA tools
+ENV CLAUDE_CODE_CONTAINER=1
+ENV CLAUDE_CODE_COMMERCIAL=1
+
+# Switch to non-root user
+USER claude
+
+# Set the entrypoint
+ENTRYPOINT ["python3", "/app/agent.py"]

--- a/examples/claude-code-agent/README.md
+++ b/examples/claude-code-agent/README.md
@@ -1,0 +1,90 @@
+# Claude Code Agent for CVDP
+
+A Docker-based agent that uses [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) to solve CVDP hardware verification challenges in an agentic workflow.
+
+## Prerequisites
+
+- Docker
+- An Anthropic API key (`sk-ant-...`)
+- (Commercial only) Access to Cadence EDA tools and a license server
+
+## Building
+
+```bash
+cd examples/claude-code-agent/
+
+# Build both images (non-commercial + commercial)
+./build_agent.sh
+
+# Or build only the non-commercial image
+docker build -t claude-code-agent .
+```
+
+To override the default license server for the commercial build:
+
+```bash
+CDS_LIC_FILE='port@server' LM_LICENSE_FILE='port@server' ./build_agent.sh
+```
+
+This produces two Docker images:
+
+| Image | Base | Use case |
+|-------|------|----------|
+| `claude-code-agent` | Ubuntu 22.04 | OSS simulators (Icarus, Verilator) |
+| `claude-code-agent-commercial` | RockyLinux 9 | Cadence Xcelium, cocotb, coverage tools |
+
+## Running
+
+Set your API key and run the benchmark from the repo root:
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+
+# Single run
+python run_benchmark.py -f dataset.jsonl -l -g claude-code-agent
+
+# Single datapoint
+python run_benchmark.py -f dataset.jsonl -i cvdp_agentic_issue_0001 -l -g claude-code-agent
+
+# Multi-sample Pass@k evaluation
+python run_samples.py -f dataset.jsonl -l -g claude-code-agent -n 5 -k 1
+
+# Commercial image (with EDA tools)
+python run_benchmark.py -f dataset.jsonl -l -g claude-code-agent-commercial
+```
+
+## Configuration
+
+| Environment Variable | Description |
+|---|---|
+| `ANTHROPIC_API_KEY` | **Required.** Anthropic API key. |
+| `CLAUDE_CODE_MAX_TURNS` | Optional. Limit the number of agent turns for fair comparison. |
+| `DOCKER_TIMEOUT_AGENT` | Optional. Agent container timeout in seconds (set in `.env`). |
+
+## How It Works
+
+1. The benchmark mounts challenge files into the container at `/code/` (docs, RTL, verification files, and `prompt.json`).
+2. `agent.py` reads the task from `/code/prompt.json`.
+3. Claude Code CLI is invoked in non-interactive project mode (`claude -p --dangerously-skip-permissions`) with the task piped via stdin.
+4. Claude iteratively reads, modifies, and tests files in the `/code/` workspace.
+5. Web search/fetch are disabled to ensure the agent works only with local files.
+6. The container exits and the benchmark evaluates the agent's changes against the test harness.
+
+## Debugging
+
+```bash
+# Run a benchmark first to generate work directories
+python run_benchmark.py -f dataset.jsonl -i cvdp_agentic_issue_0001 -l -g claude-code-agent
+
+# Inspect agent changes
+cat work/cvdp_agentic_issue_0001/harness/1/agent_changes.patch
+
+# Interactive debug shell inside the agent container
+cd work/cvdp_agentic_issue_0001/harness/1/
+./run_docker_agent.sh -d
+```
+
+## See Also
+
+- [Agentic Workflow Guide](../../README_AGENTIC.md) — full documentation on the agentic benchmark workflow
+- [Example Agent](../agent/) — minimal reference agent implementation

--- a/examples/claude-code-agent/agent.py
+++ b/examples/claude-code-agent/agent.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Claude Code agent implementation for the CVDP agentic workflow.
+This agent reads prompt.json and uses Claude Code to make changes to files.
+"""
+
+import json
+import subprocess
+import sys
+import os
+
+def main():
+    """Main agent function"""
+    print("Starting Claude Code agent...")
+
+    # Copy Claude auth files from mounted read-only location to writable location
+    # This allows Claude to update its config files during execution
+    import shutil
+    import subprocess as sp
+    home = os.path.expanduser("~")
+
+    # Don't pre-create .claude.json - let Claude CLI create it on first use
+    # Just ensure the home directory is writable
+    claude_json_path = f"{home}/.claude.json"
+    if not os.path.exists(claude_json_path):
+        print(f"Note: {claude_json_path} will be created by Claude CLI on first use")
+
+    if os.path.exists("/host-claude/.claude.json"):
+        print("Copying Claude auth files to writable location...")
+        try:
+            # Use cp command to avoid python permission issues
+            sp.run(["cp", "/host-claude/.claude.json", f"{home}/.claude.json"], check=True)
+            sp.run(["chmod", "644", f"{home}/.claude.json"], check=True)
+            print("Copied .claude.json")
+        except Exception as e:
+            print(f"Warning: Could not copy .claude.json: {e}")
+
+    if os.path.exists("/host-claude/.claude"):
+        try:
+            # Use cp command to avoid python permission issues
+            if os.path.exists(f"{home}/.claude"):
+                sp.run(["rm", "-rf", f"{home}/.claude"], check=True)
+            sp.run(["cp", "-r", "/host-claude/.claude", f"{home}/.claude"], check=True)
+            sp.run(["chmod", "-R", "755", f"{home}/.claude"], check=True)
+            print("Copied .claude directory")
+        except Exception as e:
+            print(f"Warning: Could not copy .claude directory: {e}")
+
+    # Read the task from prompt.json
+    try:
+        with open("/code/prompt.json", "r") as f:
+            prompt_data = json.load(f)
+            task = prompt_data.get("prompt", "")
+    except Exception as e:
+        print(f"Error reading prompt.json: {e}")
+        sys.exit(1)
+
+    if not task:
+        print("No task found in prompt.json. Exiting.")
+        sys.exit(1)
+
+    # Check for max turns configuration
+    max_turns = os.environ.get('CLAUDE_CODE_MAX_TURNS', None)
+    if max_turns:
+        print(f"Configuring Claude to use {max_turns} agent turns for fair comparison")
+        # Prepend turn requirement instructions to the task
+        turn_requirement = f"""IMPORTANT: For fair comparison with other agents, you should aim to use approximately {max_turns} agent turns to complete this task.
+
+An "agent turn" is one response message from you that may contain multiple tool calls. Do NOT rush to complete the task. Instead:
+
+1. Take an iterative, exploratory approach
+2. Break the work into many small steps
+3. Read and analyze files thoroughly before making changes
+4. Test and verify your changes incrementally
+5. Use multiple turns to explore, plan, implement, test, and refine
+6. Be thorough and methodical rather than trying to solve everything at once
+
+Your goal is to produce high-quality results while using the full turn budget available to you.
+
+Task:
+"""
+        task = turn_requirement + task
+
+    print(f"Task: {task[:200]}..." if len(task) > 200 else f"Task: {task}")
+
+    # Change to the code directory where files are mounted
+    os.chdir("/code")
+
+    # Setup environment - ensure we have ANTHROPIC_API_KEY
+    env = os.environ.copy()
+
+    # Check for ANTHROPIC_API_KEY in environment
+    if 'ANTHROPIC_API_KEY' not in env:
+        print("ERROR: ANTHROPIC_API_KEY not found in environment!")
+        print("Available env vars:", [k for k in env.keys() if 'KEY' in k or 'API' in k])
+        sys.exit(1)
+
+    # Validate it's an actual Anthropic key
+    api_key = env['ANTHROPIC_API_KEY']
+    if not api_key.startswith('sk-ant-'):
+        print(f"WARNING: ANTHROPIC_API_KEY does not start with 'sk-ant-' (starts with '{api_key[:10]}...')")
+        print("This may not be a valid Anthropic API key")
+        sys.exit(1)
+
+    print(f"Using Anthropic API key: {api_key[:20]}...")
+
+    # Use /tmp for Claude config to avoid home directory permission issues
+    env['CLAUDE_CONFIG_DIR'] = '/tmp/.claude'
+
+    # Enable telemetry for debugging
+    env['CLAUDE_CODE_ENABLE_TELEMETRY'] = '1'
+    env['OTEL_LOG_USER_PROMPTS'] = '1'
+    # Log to console for now (we can add proper OTLP later)
+    env['OTEL_LOGS_EXPORTER'] = 'console'
+    env['OTEL_METRICS_EXPORTER'] = 'console'
+
+    # Disable web access tools to prevent looking up solutions online
+    # This ensures the agent can only work with local files
+    env['CLAUDE_CODE_DISABLE_WEB_SEARCH'] = '1'
+    env['CLAUDE_CODE_DISABLE_WEB_FETCH'] = '1'
+    print("Web search and fetch tools are DISABLED - agent can only use local files")
+
+    # Run Claude in non-interactive mode
+    # Use stdin to pass prompt to avoid command-line length issues
+    # --dangerously-skip-permissions = bypass all permission prompts
+    print("\nInvoking Claude Code...")
+    print("=" * 80)
+    print(f"Command: echo '<task>' | claude -p --dangerously-skip-permissions")
+    print(f"Task length: {len(task)} characters")
+    print("Output will appear when task completes...")
+    print("=" * 80)
+    sys.stdout.flush()
+    sys.stderr.flush()
+
+    # Use subprocess to pipe the task via stdin
+    # This avoids command-line argument length issues
+    try:
+        result = subprocess.run(
+            ["claude", "-p", "--dangerously-skip-permissions"],
+            input=task,
+            text=True,
+            env=env,
+            cwd="/code",
+            capture_output=False  # Let output go directly to stdout/stderr
+        )
+        sys.exit(result.returncode)
+    except Exception as e:
+        print(f"\nError running Claude: {e}", file=sys.stderr)
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/examples/claude-code-agent/build_agent.sh
+++ b/examples/claude-code-agent/build_agent.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+# Default license server
+CDS_LIC_FILE="${CDS_LIC_FILE:-5280@10.4.120.82}"
+LM_LICENSE_FILE="${LM_LICENSE_FILE:-5280@10.4.120.82}"
+
+echo "Building Claude Code agent Docker images..."
+echo ""
+
+# Build non-commercial version (no EDA tools)
+echo "1. Building claude-code-agent (non-commercial)..."
+docker build -t claude-code-agent .
+echo "✓ claude-code-agent build complete"
+echo ""
+
+# Build commercial version (with EDA tools)
+echo "2. Building claude-code-agent-commercial (with EDA tools)..."
+echo "   Using license server: $CDS_LIC_FILE"
+docker build \
+    --build-arg CDS_LIC_FILE="$CDS_LIC_FILE" \
+    --build-arg LM_LICENSE_FILE="$LM_LICENSE_FILE" \
+    -f Dockerfile.commercial \
+    -t claude-code-agent-commercial .
+echo "✓ claude-code-agent-commercial build complete"
+echo ""
+
+echo "=========================================="
+echo "Build complete! Docker images are ready:"
+echo "  - claude-code-agent (non-commercial)"
+echo "  - claude-code-agent-commercial (with EDA tools)"
+echo "=========================================="
+echo ""
+echo "To run the agent with the benchmark:"
+echo "  Non-commercial: ./run_benchmark.py -f <dataset.jsonl> -l -g claude-code-agent"
+echo "  Commercial:     ./run_benchmark.py -f <dataset.jsonl> -l -g claude-code-agent-commercial"
+echo ""
+echo "To use a different license server:"
+echo "  CDS_LIC_FILE='port@server' ./build_agent.sh"

--- a/examples/claude-code-agent/build_agent.sh
+++ b/examples/claude-code-agent/build_agent.sh
@@ -5,9 +5,9 @@
 
 set -e
 
-# Default license server
-CDS_LIC_FILE="${CDS_LIC_FILE:-5280@10.4.120.82}"
-LM_LICENSE_FILE="${LM_LICENSE_FILE:-5280@10.4.120.82}"
+# Default license server (override by setting env vars before running this script)
+CDS_LIC_FILE="${CDS_LIC_FILE:-5280@your-license-server}"
+LM_LICENSE_FILE="${LM_LICENSE_FILE:-5280@your-license-server}"
 
 echo "Building Claude Code agent Docker images..."
 echo ""

--- a/src/dataset_processor.py
+++ b/src/dataset_processor.py
@@ -1617,7 +1617,9 @@ class AgenticProcessor (DatasetProcessor):
                         ],
                         'working_dir': '/code',
                         'environment': {
-                            'OPENAI_USER_KEY': config.get('OPENAI_USER_KEY', '')
+                            'OPENAI_USER_KEY': config.get('OPENAI_USER_KEY', ''),
+                            'ANTHROPIC_API_KEY': config.get('ANTHROPIC_API_KEY', ''),
+                            'CLAUDE_CODE_MAX_TURNS': os.environ.get('CLAUDE_CODE_MAX_TURNS', ''),
                         }
                     }
                 },
@@ -1643,7 +1645,9 @@ class AgenticProcessor (DatasetProcessor):
                         ],
                         'working_dir': '/code',
                         'environment': {
-                            'OPENAI_USER_KEY': config.get('OPENAI_USER_KEY', '')
+                            'OPENAI_USER_KEY': config.get('OPENAI_USER_KEY', ''),
+                            'ANTHROPIC_API_KEY': config.get('ANTHROPIC_API_KEY', ''),
+                            'CLAUDE_CODE_MAX_TURNS': os.environ.get('CLAUDE_CODE_MAX_TURNS', ''),
                         }
                     }
                 }


### PR DESCRIPTION
Add Claude Code agent example for CVDP benchmark

Adds a containerized agent that uses [Claude Code](https://docs.anthropic.com/en/docs/claude-code) to solve CVDP hardware verification challenges in a fully agentic workflow. Default model is Claude Sonnet 4.5.

- Runs as a non-root user inside the container (required by Claude Code's `--dangerously-skip-permissions` flag).
- Tasks are passed via stdin to avoid command-line length limits.
- The optional `CLAUDE_CODE_MAX_TURNS` variable injects turn-budgeting instructions into the prompt for fair cross-agent comparison.

---

### Changes

**`agent.py`**
Lightweight wrapper that reads the task from `/code/prompt.json`, pipes it to the Claude Code CLI in headless non-interactive mode (`claude -p --dangerously-skip-permissions`), and streams output. Web search and fetch tools are disabled so the agent works exclusively with mounted challenge files.

**`Dockerfile`**
Non-commercial image (Ubuntu 22.04) with Node.js 20, Python 3, and the Claude Code CLI. Compatible with OSS simulators (Icarus Verilog, Verilator).

**`Dockerfile.commercial`**
Commercial image (Rocky Linux 9) with Cadence Xcelium, cocotb, and coverage tooling. Accepts `CDS_LIC_FILE` / `LM_LICENSE_FILE` build args for license server configuration.

**`build_agent.sh`**
Helper script that builds both Docker images in one step.

**`README.md`**
Build, run, configuration, and debugging instructions.

**`AgenticProcessor`**
Updated to pass `ANTHROPIC_API_KEY` and `CLAUDE_CODE_MAX_TURNS` environment variables through to agent containers.

---

### Results (pass@1, n=5)

| Image                                | pass@1 |
| ------------------------------------ | ------ |
| `claude-code-agent` (non-commercial) | 44.5%  |
| `claude-code-agent-commercial`       | 9.2%   |

---

### Testing

```bash
export ANTHROPIC_API_KEY=sk-ant-...

# Full benchmark
python run_benchmark.py -f dataset.jsonl -l -g claude-code-agent

# Multi-sample pass@k
python run_samples.py -f dataset.jsonl -l -g claude-code-agent -n 5 -k 1
```