### PR TITLE
fix(harness): preserve per-service test accounting on timeout

### DIFF
--- a/src/repository.py
+++ b/src/repository.py
@@ -346,7 +346,7 @@ class Repository:
             if kill:
                 subprocess.run(kill, shell = True)
 
-            return p.returncode, pid
+            return 124, pid
 
         return p.returncode, pid
 
@@ -958,7 +958,7 @@ class Repository:
                 service_log = f'{logfile}{f"_{service}" if len(services) > 1 else ""}.txt'
                 opts   = self.docker_cmd(issue_path)
                 result = self.log_docker(docker, opts, service, service_log)
-                error += result['result']
+                error += int(result['result'] != 0)
                 results.append(result)
 
         else:


### PR DESCRIPTION
When a harness container timed out, timeout handling could propagate a non-usable status into aggregation.
That could short-circuit to a single fallback failure for the whole datapoint, dropping other service-level
results from accounting. In multi-service cases this undercounted total tests (often removing passes) and
skewed the final pass rate.

- Return an explicit non-zero timeout status (124) for timed-out runs.
- Count service outcomes with binary semantics (exit_code != 0) instead of summing raw exit codes.

This makes reporting consistent: each service contributes one test result, timed-out services are failed,
and total/passed/failed numbers reflect all executed service outcomes.