### PR TITLE
Add CVDP heavy-agentic local repo support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,3 +35,6 @@
 
 # Enable LLM-based subjective scoring (defaults shown in comments)
 # ENABLE_SUBJECTIVE_SCORING=false 
+
+# Path to directory containing cvdp_agentic_heavy_* local git repos (unpacked clean bundles)
+# CVDP_HEAVY_REPOS_PATH=/path/to/cvdp_agentic_heavy_clean_inspect

--- a/docker/requirements.in
+++ b/docker/requirements.in
@@ -4,3 +4,6 @@ cocotb==2.0.1
 pytest==8.3.2
 aes
 coverage
+cocotb-bus==0.3.0
+cocotbext-axi==0.1.28
+cocotbext-pcie @ git+https://github.com/alexforencich/cocotbext-pcie.git@92732edd2d8cef002f0e984697ff31ccfe8a19a9

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -51,6 +51,24 @@ cocotb==2.0.1 \
     --hash=sha256:fa8501f3299f753f7484604db07747790b66f0e4c99e51fc51885df4bf17af44 \
     --hash=sha256:faf3ec2916d2392bfa22825d46615c55fc23a3c0e93e5d8bba56aaeda1245cf7 \
     --hash=sha256:fed79b086414ac2d5faa1eff74b7533cb46404dfcd5a8e52cdffaeecdf98033a
+    # via
+    #   -r docker/requirements.in
+    #   cocotb-bus
+    #   cocotbext-axi
+    #   cocotbext-pcie
+cocotb-bus==0.3.0 \
+    --hash=sha256:9762b29273ff062f52160e57274e3cb106d14e7e776515de1372c1d73546b005 \
+    --hash=sha256:b4f06cce2462a8f9487b42c46b0ff3afd253f0fa4f67a0c382ebe0ba614229eb
+    # via
+    #   -r docker/requirements.in
+    #   cocotbext-axi
+cocotbext-axi==0.1.28 \
+    --hash=sha256:5d062185b9bb5476839a1d816821c4533b245f56f7b171b3f39130e26891ae37 \
+    --hash=sha256:aff88b528733e4e59359f06b8cc30524cc75bf31ee951ed8a573694b26816eb2
+    # via
+    #   -r docker/requirements.in
+    #   cocotbext-pcie
+cocotbext-pcie @ git+https://github.com/alexforencich/cocotbext-pcie.git@92732edd2d8cef002f0e984697ff31ccfe8a19a9
     # via -r docker/requirements.in
 coverage==7.13.4 \
     --hash=sha256:01d4cbc3c283a17fc1e42d614a119f7f438eabb593391283adca8dc86eff1246 \
@@ -180,3 +198,7 @@ pytest==8.3.2 \
     --hash=sha256:4ba08f9ae7dcf84ded419494d229b48d0903ea6407b030eaec46df5e6a73bba5 \
     --hash=sha256:c132345d12ce551242c87269de812483f5bcc87cdbb4722e48487ba194f9fdce
     # via -r docker/requirements.in
+scapy==2.7.0 \
+    --hash=sha256:bfc1ef1b93280aea1ddee53be7f74232aa28ac3d891244d41ee85200d24aa446 \
+    --hash=sha256:eb22786da92be6fd8e5c694ae5595e4f5b9ac1f4364c9c45986844f3e3063561
+    # via cocotb-bus

--- a/examples/cadence_docker/Dockerfile
+++ b/examples/cadence_docker/Dockerfile
@@ -40,4 +40,9 @@ ENV LM_LICENSE_FILE="$CDS_LIC_FILE"
 RUN dnf -y install python3.12
 ADD https://bootstrap.pypa.io/get-pip.py get-pip.py
 RUN python3 ./get-pip.py
-RUN python3 -m pip install pytest=9.0.2 pytest-timeout==2.4.0
+RUN python3 -m pip install --no-cache-dir \
+    pytest==9.0.2 \
+    pytest-timeout==2.4.0 \
+    cocotb==2.0.1 \
+    coverage \
+    aes

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -120,7 +120,7 @@ class ConfigManager:
                            description="Path to directory containing cvdp_agentic_heavy_* local git repos (unpacked clean bundles)")
         
         # Docker and Resource Management
-        self.register_config("DOCKER_QUOTA_THRESHOLD_MB", default=50, type_cast=int,
+        self.register_config("DOCKER_QUOTA_THRESHOLD_MB", default=200, type_cast=int,
                            description="Docker quota threshold in MB")
         self.register_config("DOCKER_QUOTA_CHECK_INTERVAL", default=1, type_cast=int,
                            description="Docker quota check interval in seconds")

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -116,6 +116,8 @@ class ConfigManager:
                            description="Default model to use when none is specified")
         self.register_config("CUSTOM_MODEL_FACTORY", required=False,
                            description="Path to custom model factory implementation")
+        self.register_config("CVDP_HEAVY_REPOS_PATH", required=False,
+                           description="Path to directory containing cvdp_agentic_heavy_* local git repos (unpacked clean bundles)")
         
         # Docker and Resource Management
         self.register_config("DOCKER_QUOTA_THRESHOLD_MB", default=50, type_cast=int,

--- a/src/dataset_processor.py
+++ b/src/dataset_processor.py
@@ -2331,6 +2331,11 @@ class AgenticProcessor (DatasetProcessor):
         commit_sha = getattr(self, "commit_hash", None) or ctx.get("context", {}).get("commit")
         data_point = id.split("_")
 
+        # Resolve bare repo name to full local path when CVDP_HEAVY_REPOS_PATH is set
+        cvdp_heavy_repos_path = config.get("CVDP_HEAVY_REPOS_PATH")
+        if cvdp_heavy_repos_path and repo_url and not os.path.isabs(repo_url) and "://" not in repo_url and "@" not in repo_url:
+            repo_url = os.path.join(cvdp_heavy_repos_path, repo_url)
+
         try:
             if not os.getenv("CLONE_HTTP") and "github.com/" in repo_url if repo_url else False:
                 repo_url   = repo_url.split("github.com/")[-1]
@@ -2348,8 +2353,14 @@ class AgenticProcessor (DatasetProcessor):
             # Get patches if available
             patches = ctx.get('patch', {}) if not self.disable_patch else {}
             
-            # Determine root directory (extract only external/ folder for CVDP repos)
-            root_dir = "external" if 'cvdp_' in repo_url or 'cvdp-' in repo_url else None
+            # Determine root directory (extract only external/ folder for CVDP repos).
+            # _ext_ repos (e.g. cvdp_agentic_heavy_ext_cheriot-ibex) ARE the external code
+            # at the repo root — no external/ subdirectory exists in them.
+            root_dir = (
+                "external"
+                if ('cvdp_' in repo_url or 'cvdp-' in repo_url) and '_ext_' not in repo_url
+                else None
+            )
             
             # Create the git workspace using the consolidated approach
             success = git_manager.create_volume_with_checkout(

--- a/src/git_utils.py
+++ b/src/git_utils.py
@@ -24,6 +24,53 @@ from .config_manager import config
 _repo_locks: Dict[str, threading.Lock] = defaultdict(threading.Lock)
 
 
+def get_repo_hash(repo_url: str) -> str:
+    """
+    Generate a consistent hash for a repository URL or local path key.
+
+    Args:
+        repo_url: Git repository URL or normalized local path
+
+    Returns:
+        8-character hex hash of the repository key
+    """
+    return hashlib.md5(repo_url.encode()).hexdigest()[:8]
+
+
+def normalize_repo_url(repo_url: str) -> str:
+    """
+    Normalize repository URL for consistent handling.
+
+    Args:
+        repo_url: Original repository URL
+
+    Returns:
+        Normalized repository URL (SSH vs HTTPS based on CLONE_HTTP env var)
+    """
+    try:
+        # Convert GitHub HTTPS URLs to SSH unless CLONE_HTTP is set
+        if not os.getenv("CLONE_HTTP") and "github.com/" in repo_url:
+            if repo_url.startswith("https://github.com/"):
+                repo_path = repo_url.replace("https://github.com/", "")
+                if not repo_path.endswith(".git"):
+                    repo_path += ".git"
+                return f"git@github.com:{repo_path}"
+            elif "github.com/" in repo_url and not repo_url.startswith("git@"):
+                repo_path = repo_url.split("github.com/")[-1]
+                if not repo_path.endswith(".git"):
+                    repo_path += ".git"
+                return f"git@github.com:{repo_path}"
+        return repo_url
+    except Exception:
+        return repo_url
+
+
+def get_repo_mirror_filename(repo_url: str) -> str:
+    """Return the mirror directory name used for a repository URL or local path."""
+    mirror_key = os.path.abspath(repo_url) if os.path.isdir(repo_url) else normalize_repo_url(repo_url)
+    return f"{get_repo_hash(mirror_key)}.git"
+
+
 class GitRepositoryManager:
     """
     Manages shared git repositories and Docker volumes for context-heavy agentic datapoints.
@@ -101,7 +148,7 @@ class GitRepositoryManager:
         Returns:
             8-character hex hash of the repository URL
         """
-        return hashlib.md5(repo_url.encode()).hexdigest()[:8]
+        return get_repo_hash(repo_url)
     
     def _normalize_repo_url(self, repo_url: str) -> str:
         """
@@ -113,43 +160,70 @@ class GitRepositoryManager:
         Returns:
             Normalized repository URL (SSH vs HTTPS based on CLONE_HTTP env var)
         """
-        try:
-            # Convert GitHub HTTPS URLs to SSH unless CLONE_HTTP is set
-            if not os.getenv("CLONE_HTTP") and "github.com/" in repo_url:
-                if repo_url.startswith("https://github.com/"):
-                    repo_path = repo_url.replace("https://github.com/", "")
-                    if not repo_path.endswith(".git"):
-                        repo_path += ".git"
-                    return f"git@github.com:{repo_path}"
-                elif "github.com/" in repo_url and not repo_url.startswith("git@"):
-                    repo_path = repo_url.split("github.com/")[-1]
-                    if not repo_path.endswith(".git"):
-                        repo_path += ".git"
-                    return f"git@github.com:{repo_path}"
-            return repo_url
-        except Exception:
-            return repo_url
+        return normalize_repo_url(repo_url)
     
     def get_or_create_mirror(self, repo_url: str) -> str:
         """
         Get or create a shared mirror for the given repository URL.
-        
+
         Args:
-            repo_url: Git repository URL
-            
+            repo_url: Git repository URL or local directory path
+
         Returns:
             Path to the shared mirror directory
         """
+        # Handle local directory paths — create a bare mirror from them
+        if os.path.isdir(repo_url):
+            abs_path = os.path.abspath(repo_url)
+            mirror_filename = get_repo_mirror_filename(repo_url)
+            repo_hash = mirror_filename.removesuffix(".git")
+            mirror_path = os.path.join(self.mirrors_dir, mirror_filename)
+            log_file = os.path.join(self.logs_dir, f"{repo_hash}_clone.log")
+
+            with _repo_locks[mirror_path]:
+                if not os.path.exists(mirror_path):
+                    print(f"[INFO] Creating mirror from local repo {abs_path}")
+                    with open(log_file, 'w') as logfile:
+                        try:
+                            subprocess.run(
+                                ["git", "clone", "--mirror", "--local", abs_path, mirror_path],
+                                check=True,
+                                stdout=logfile,
+                                stderr=subprocess.STDOUT,
+                                text=True
+                            )
+                            # Allow the patch container to fetch by SHA (orphan commits are
+                            # branch tips, so they're reachable from advertised refs)
+                            subprocess.run(
+                                ["git", "config", "uploadpack.allowReachableSHA1InWant", "true"],
+                                cwd=mirror_path,
+                                check=True,
+                                stdout=logfile,
+                                stderr=subprocess.STDOUT,
+                                text=True
+                            )
+                            print(f"[INFO] Successfully created mirror from local repo: {mirror_path}")
+                        except subprocess.CalledProcessError as e:
+                            print(f"[ERROR] Failed to mirror local repo {abs_path}: {e}")
+                            if os.path.exists(mirror_path):
+                                subprocess.run(["rm", "-rf", mirror_path], check=False)
+                            raise
+                else:
+                    print(f"[INFO] Using existing mirror for local repo: {mirror_path}")
+
+            return os.path.abspath(mirror_path)
+
         normalized_url = self._normalize_repo_url(repo_url)
-        repo_hash = self._get_repo_hash(normalized_url)
-        mirror_path = os.path.join(self.mirrors_dir, f"{repo_hash}.git")
+        mirror_filename = get_repo_mirror_filename(repo_url)
+        repo_hash = mirror_filename.removesuffix(".git")
+        mirror_path = os.path.join(self.mirrors_dir, mirror_filename)
         log_file = os.path.join(self.logs_dir, f"{repo_hash}_clone.log")
-        
+
         # Use per-repository locking to prevent concurrent operations
         with _repo_locks[mirror_path]:
             if not os.path.exists(mirror_path):
                 print(f"[INFO] Cloning {normalized_url} into shared mirror at {mirror_path}")
-                
+
                 with open(log_file, 'w') as logfile:
                     try:
                         subprocess.run(
@@ -183,7 +257,7 @@ class GitRepositoryManager:
                     except subprocess.CalledProcessError as e:
                         print(f"[WARNING] Failed to update mirror {mirror_path}: {e}")
                         # Don't fail on update errors - use existing mirror
-        
+
         return os.path.abspath(mirror_path)
     
     def create_volume_with_checkout(self, 

--- a/src/repository.py
+++ b/src/repository.py
@@ -9,6 +9,7 @@ import yaml
 import psutil
 from src import subjective
 from src import network_util
+from src import git_utils
 import dotenv
 from src.dir_monitor import DirectorySizeMonitor
 from src.config_manager import config
@@ -48,7 +49,7 @@ def apply_template_substitution(content: str) -> str:
     
     Replaces placeholders in the format __VARIABLE__ with configured values:
     - __VERIF_EDA_IMAGE__ -> VERIF_EDA_IMAGE config value
-    - __LICENSE_NETWORK__ -> LICENSE_NETWORK config value  
+    - __LICENSE_NETWORK__ -> LICENSE_NETWORK config value
     - __OSS_SIM_IMAGE__ -> OSS_SIM_IMAGE config value
     - __OSS_PNR_IMAGE__ -> OSS_PNR_IMAGE config value
     
@@ -63,7 +64,7 @@ def apply_template_substitution(content: str) -> str:
         '__VERIF_EDA_IMAGE__': config.get('VERIF_EDA_IMAGE'),
         '__LICENSE_NETWORK__': config.get('LICENSE_NETWORK'),
         '__OSS_SIM_IMAGE__': config.get('OSS_SIM_IMAGE'),
-        '__OSS_PNR_IMAGE__': config.get('OSS_PNR_IMAGE')
+        '__OSS_PNR_IMAGE__': config.get('OSS_PNR_IMAGE'),
     }
     
     # Apply substitutions for any placeholders found
@@ -547,28 +548,22 @@ class Repository:
             
             if repo_url and commit_hash:
                 # Find existing git cache mirror
+                # Compute the repo hash at generation time so the script points
+                # directly at the same mirror path used by GitRepositoryManager.
+                mirror_filename = git_utils.get_repo_mirror_filename(repo_url)
+
                 script_file.write("# Look for existing git cache mirror\n")
                 script_file.write("SCRIPT_DIR=\"$(cd \"$(dirname \"${BASH_SOURCE[0]}\")\" && pwd)\"\n")
                 script_file.write("WORK_DIR=\"$(dirname \"$(dirname \"$(dirname \"$SCRIPT_DIR\")\")\")\"  # Go up to work directory\n")
                 script_file.write("GIT_CACHE_DIR=\"$WORK_DIR/git_cache/mirrors\"\n")
-                script_file.write("MIRROR_DIR=\"\"\n\n")
-                
-                script_file.write("# Find the mirror directory (should be named with repo hash)\n")
-                script_file.write("if [ -d \"$GIT_CACHE_DIR\" ]; then\n")
-                script_file.write("  for mirror in \"$GIT_CACHE_DIR\"/*.git; do\n")
-                script_file.write("    if [ -d \"$mirror\" ]; then\n")
-                script_file.write("      MIRROR_DIR=\"$mirror\"\n")
-                script_file.write("      echo \"Found git cache mirror: $MIRROR_DIR\"\n")
-                script_file.write("      break\n")
-                script_file.write("    fi\n")
-                script_file.write("  done\n")
-                script_file.write("fi\n\n")
-                
-                script_file.write("if [ -z \"$MIRROR_DIR\" ]; then\n")
-                script_file.write("  echo \"ERROR: No git cache mirror found in $GIT_CACHE_DIR\"\n")
+                script_file.write(f"MIRROR_DIR=\"$GIT_CACHE_DIR/{mirror_filename}\"\n\n")
+
+                script_file.write("if [ ! -d \"$MIRROR_DIR\" ]; then\n")
+                script_file.write("  echo \"ERROR: Expected git cache mirror not found: $MIRROR_DIR\"\n")
                 script_file.write("  echo \"Please run the benchmark with -l -g first to create the git cache.\"\n")
                 script_file.write("  exit 1\n")
-                script_file.write("fi\n\n")
+                script_file.write("fi\n")
+                script_file.write("echo \"Found git cache mirror: $MIRROR_DIR\"\n\n")
                 
                 # Ensure patch_image exists
                 script_file.write("# Ensure patch_image Docker image exists\n")

--- a/tools/sanity_check.py
+++ b/tools/sanity_check.py
@@ -25,6 +25,9 @@ Examples:
 
   # Resume a partial run (skip already-completed work dirs):
   python tools/sanity_check.py -s -t 4
+
+  # Run against specific files (bypasses --dataset-dir discovery):
+  python tools/sanity_check.py path/to/dataset1.json path/to/dataset2.json -t 4
 """
 
 import argparse
@@ -166,6 +169,11 @@ def main() -> int:
         epilog=__doc__,
     )
     parser.add_argument(
+        "files",
+        nargs="*",
+        help="Dataset file(s) to check directly (bypasses --dataset-dir discovery)",
+    )
+    parser.add_argument(
         "--dataset-dir",
         default=DEFAULT_DATASET_DIR,
         help=f"Directory containing dataset files (default: {DEFAULT_DATASET_DIR})",
@@ -202,13 +210,21 @@ def main() -> int:
     if args.only_golden and args.only_nopatch:
         parser.error("--only-golden and --only-nopatch are mutually exclusive")
 
-    # Discover dataset files
-    dataset_files = discover_datasets(args.dataset_dir, args.filter_str)
-    if not dataset_files:
-        print(f"ERROR: No dataset files found in {args.dataset_dir} matching '{DATASET_GLOB}'")
-        if args.filter_str:
-            print(f"       (with filter: '{args.filter_str}')")
-        return 1
+    # Use explicit files if provided, otherwise discover from --dataset-dir
+    if args.files:
+        missing = [f for f in args.files if not os.path.isfile(f)]
+        if missing:
+            for f in missing:
+                print(f"ERROR: File not found: {f}")
+            return 1
+        dataset_files = [os.path.abspath(f) for f in args.files]
+    else:
+        dataset_files = discover_datasets(args.dataset_dir, args.filter_str)
+        if not dataset_files:
+            print(f"ERROR: No dataset files found in {args.dataset_dir} matching '{DATASET_GLOB}'")
+            if args.filter_str:
+                print(f"       (with filter: '{args.filter_str}')")
+            return 1
 
     modes = []
     if not args.only_nopatch:


### PR DESCRIPTION
## Summary
- Add `CVDP_HEAVY_REPOS_PATH` config for local heavy-agentic repo bundles
- Support local repo mirrors and consistent mirror lookup for generated workspace scripts
- Handle `_ext_` heavy repos whose content lives at repo root
- Add heavy harness Python dependencies
- Allow `tools/sanity_check.py` to run explicit dataset files
