### PR TITLE
#53 - Tell the model its response replaces the whole file when the output file is also an input

### DIFF
--- a/src/dataset_processor.py
+++ b/src/dataset_processor.py
@@ -1115,6 +1115,16 @@ class CopilotProcessor (DatasetProcessor):
             # Add additional instructions based on expected files
             if len(files) == 1:
                 prompt += f"Please provide your response as plain text without any JSON formatting. Your response will be saved directly to: {files[0]}.\n"
+                # When the expected output file is also one of the input files, the
+                # writeback below replaces it whole rather than merging into it.
+                # Say so, or a category whose guidance asks for a fragment -- cid14
+                # asks for the assertions only -- returns that fragment alone and
+                # the rest of the file, typically the design under test, is
+                # silently deleted. Scoped to the single-file case, which is where
+                # cid14 lives; the multi-file writeback has the same hazard and is
+                # deliberately left alone here.
+                if files[0] in context['input']['context']:
+                    prompt += f"{files[0]} is shown above and your response replaces all of it, so return the whole file, with everything you are not changing kept exactly as it is.\n"
             elif len(files) > 1:
                 prompt += f"Name the files as: {files}.\n"
             else:

--- a/src/model_helpers.py
+++ b/src/model_helpers.py
@@ -66,7 +66,7 @@ When generating files, return the file name in the correct place at the folder s
             10: "You are solving a 'Question & Answer on Testbench' problem. To solve this problem correctly, you should only respond with a detailed answer to the question about the testbench.",
             12: "You are solving a 'Test Plan to Testbench Stimulus Generation' problem. To solve this problem correctly, you should only respond with the testbench stimulus code generated based on the test plan specification.",
             13: "You are solving a 'Test Plan to Testbench Checker Generation' problem. To solve this problem correctly, you should only respond with the testbench checker code generated based on the test plan specification.",
-            14: "You are solving a 'Test Plan to Assertions Generation' problem. To solve this problem correctly, you should only respond with the assertions for the testbench based on the test plan specification.",
+            14: "You are solving a 'Test Plan to Assertions Generation' problem. To solve this problem correctly, you should respond with the assertions for the testbench based on the test plan specification, and with no explanation or commentary. If the file your response is saved to was given to you in the context, return that whole file with the assertions added, changing only what the assertions require, because your response replaces the file.",
             16: "You are solving an 'RTL Debugging and Bug Fixing' problem. To solve this problem correctly, you should only respond with the RTL code that is debugged and fixed to address the bug."
         }
         if category is not None and category in self.category_guidance:


### PR DESCRIPTION
Fixes #53.

For 66 of the 67 cid14 datapoints the expected output file is one of the files already shown to the model in the prompt, and the writeback replaces that file in full. Nothing in the prompt said so, while the cid14 system prompt asked for "only ... the assertions", so a model that followed it returned the assertions alone and the design under test was deleted.

## Changes

**`src/dataset_processor.py`** — when the expected output file is also one of the input files, say that the response replaces it. The condition is structural, not category-based: it fires exactly when `files[0]` appears in `input.context`, so it needs no list of categories to maintain and covers future datapoints with the same shape.

```
rtl/brent_kung_adder.sv is shown above and your response replaces all of it,
so return the whole file, with everything you are not changing kept exactly as it is.
```

The wording is deliberately balanced in two directions. "everything you are **not changing**" presupposes that some parts *are* changed, so it does not block the datapoints whose test plan forces a header edit — five cid14 DUTs have no clock signal at all, and a temporal assertion there requires the model to add a clock port. "kept exactly as it is" pushes against rewriting the parts that should be copied.

Scoped to the single-file branch. The multi-file writeback (`result[filename] = cxt[filename]`) replaces whole files the same way and has the same hazard, but no category we could measure exercises that path, so it is left alone and noted in a comment rather than changed blind.

**`src/model_helpers.py`** — the cid14 guidance said "you should only respond with the assertions", which contradicts the writeback. It now asks for the whole file with the assertions added, "changing only what the assertions require", and keeps the original intent that the reply carry no explanation or commentary. No other category's guidance is touched.

## Verification

**Prompt assembly, 70 datapoints, no model calls.** A stub model captured the assembled system and user prompts before and after the change, for every datapoint in `example_dataset/` plus all 67 cid14 datapoints:

| | count | result |
|---|---:|---|
| cid003 / cid010 / cid012 (example dataset) | 3 | system and user prompt byte-identical |
| cid014, output file also an input file | 66 | new user-prompt line + reworded system prompt |
| cid014, output file is new (`cvdp_copilot_asyc_reset_0001`) | 1 | no user-prompt line, as intended |

Four synthetic datapoints additionally confirmed the multi-file and zero-output-file branches are untouched.

**Model behaviour, 20 cid14 datapoints, gpt-5.6-sol, n=1.** A stratified sample — all 5 DUTs of 300 lines or more, 2 picked because their DUT looked to be missing a clock port, and 13 drawn at random from the rest. Whether the DUT survived is decided by the same predicate used for the numbers in #53 (do the original module names still appear in the written file):

| | baseline (same 20, 5 samples) | with this change (n=1) |
|---|---:|---:|
| DUT deleted | 92/100 (92.0%) | **0/20** |
| datapoints that failed every sample | 17/20 | — |

Beyond survival, 18 of the 20 replies reproduced **100% of the original file's lines verbatim** and appended only new lines; a 19th reproduced 99.8% (448 lines, one line changed). `cvdp_copilot_32_bit_Brent_Kung_PP_adder_0008`, the clockless case, kept all 78 original lines and added `input logic clk` to the port list — the header edit the test plan needs is not blocked by the new wording.

## Known limitations

**One datapoint comes back with its DUT rewritten rather than reproduced.** `cvdp_copilot_lfsr_0073` returned a complete, self-contained 146-line `lfsr_16bit` in place of the original 773; 13.5% of the original's non-blank lines survived. This is not truncation and not omission — the module ends properly, there are no elision markers, and the counts of `always` / `assign` / `wire` blocks match. The original body is four `case (weight)` blocks, each enumerating all 16 values of a 4-bit input with hand-unrolled bit expressions across roughly 175 lines. The reply has no `case` at all: the model inferred the rule behind the enumeration and wrote its general form. **Whether the rewrite is functionally equivalent to the original is not verified here** — it would need a simulator this environment does not have — so this datapoint should be treated as measuring the model's own design, not the one the benchmark supplies.

It is the dataset's extreme outlier at 83,012 characters; the next largest cid14 DUT is 17,942 characters and reproduced at 99.8%, while the 575-line and 464-line DUTs reproduced at 100%. Exactly 1 of 66 exceeds 25,000 characters. Rewording did not help: an earlier phrasing produced 3,985 characters and the current one 3,797, so an instruction change is unlikely to be the lever here.

**No end-to-end re-run.** The measurement above is structural and needs no simulator. It matches what this change claims — that the response stops deleting the design — and deliberately does not claim an improvement in assertion quality. The re-assembly experiment in #53 (6.87% to 40.90% pass@1 on the same responses) is the estimate of what removing the format factor is worth; this PR does not re-measure it.

**Published cid14 numbers will move.** Any score measured under the old prompt is not comparable with one measured after this change, including the cid14 column of Table 2.

No documentation changes: no file under the repo describes prompt assembly or the category guidance strings.

## Environment

Repo `8e894cf`; dataset `cvdp_v1.1.0_nonagentic_code_generation_commercial.jsonl` (cid14 subset, 67 datapoints); `MODEL_TIMEOUT=300`. The model call goes through `--custom-factory`, which calls the stock `ModelHelpers.create_system_prompt()` and `parse_model_response()`. Two local changes to `src/repository.py` — an extra volume mount and dropping `--user $UID:$GID` under rootless podman — are not part of this PR and affect only container startup, not prompt assembly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDALmGVyEbihS9uChYnCte
